### PR TITLE
implemented the todo for single comments, strings no longer escape the c...

### DIFF
--- a/elm-font-lock.el
+++ b/elm-font-lock.el
@@ -35,7 +35,7 @@
 
 ;; Comments
 (defconst regexp-single-line-comment
-  "--.+$")
+  "--.*$")
 ;;  "--[^\\\n]*")
 ;; also works, but if you C-Shift-; font-lock-defaults <ret>
 ;; the newline isn't being escaped... lisp wtf?


### PR DESCRIPTION
...omment face (however, an open string quote with no closing quote will stringify the rest of the code until it is closed, don't think there is a way to get around this, since strings are at the syntax level of font highlighting); changed some of the regexps to use [:space:] character classes; changed the formatting of the lists and symbols to make it compatible with the regexps, in particular the make-local-variable line --- eval of font-lock-defaults should return a list with regexps and values, etc., before it returned the variable elm-font-lock-highlighting, not sure how it was font-locking; emacs lisp is weird
