### PR TITLE
Fix file header for ELPA compatibility

### DIFF
--- a/elm-compile.el
+++ b/elm-compile.el
@@ -1,3 +1,10 @@
+;;; elm-compile.el --- Elm compilation sub-mode
+
+;; Copyright (C) 2013, 2014  Joseph Collard
+
+;; Author: Joseph Collard
+;; URL: https://github.com/jcollard/elm-mode
+
 ;; This file is not part of GNU Emacs.
 
 ;; This file is free software; you can redistribute it and/or modify
@@ -13,7 +20,9 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-;; Provides useful utility functions
+;;; Commentary:
+
+;;; Code:
 
 (require 'elm-util)
 
@@ -57,3 +66,5 @@
   (elm-compile (buffer-local-file-name)))
 
 (provide 'elm-compile)
+
+;;; elm-compile.el ends here

--- a/elm-font-lock.el
+++ b/elm-font-lock.el
@@ -1,3 +1,10 @@
+;;; elm-font-lock.el --- Font locking module for Elm mode
+
+;; Copyright (C) 2013, 2014  Joseph Collard
+
+;; Author: Joseph Collard
+;; URL: https://github.com/jcollard/elm-mode
+
 ;; This file is not part of GNU Emacs.
 
 ;; This file is free software; you can redistribute it and/or modify
@@ -12,6 +19,10 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
 
 (require 'font-lock)
 (with-no-warnings (require 'cl))
@@ -85,3 +96,5 @@
 
 
 (provide 'elm-font-lock)
+
+;;; elm-font-lock.el ends here

--- a/elm-map.el
+++ b/elm-map.el
@@ -1,3 +1,10 @@
+;;; elm-map.el ---
+
+;; Copyright (C) 2013, 2014  Joseph Collard
+
+;; Author: Joseph Collard
+;; URL: https://github.com/jcollard/elm-mode
+
 ;; This file is not part of GNU Emacs.
 
 ;; This file is free software; you can redistribute it and/or modify
@@ -12,6 +19,10 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
 
 (require 'elm-repl)
 (require 'elm-compile)
@@ -53,3 +64,5 @@ For detail, see `comment-dwim'."
       '("Preview Buffer" . elm-preview-buffer)))
 
 (provide 'elm-map)
+
+;;; elm-map.el ends here

--- a/elm-mode.el
+++ b/elm-mode.el
@@ -1,3 +1,10 @@
+;;; elm-mode.el --- Major mode for Elm
+
+;; Copyright (C) 2013, 2014  Joseph Collard
+
+;; Author: Joseph Collard
+;; URL: https://github.com/jcollard/elm-mode
+
 ;; This file is not part of GNU Emacs.
 
 ;; This file is free software; you can redistribute it and/or modify
@@ -12,6 +19,10 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
 
 ;; Elm mode hook for user defined functionality
 (defvar elm-mode-hook nil)
@@ -46,3 +57,5 @@
   (run-hooks 'elm-mode-hook))
 
 (provide 'elm-mode)
+
+;;; elm-mode.el ends here

--- a/elm-preview.el
+++ b/elm-preview.el
@@ -1,3 +1,10 @@
+;;; elm-preview.el ---
+
+;; Copyright (C) 2013, 2014  Joseph Collard
+
+;; Author: Joseph Collard
+;; URL: https://github.com/jcollard/elm-mode
+
 ;; This file is not part of GNU Emacs.
 
 ;; This file is free software; you can redistribute it and/or modify
@@ -12,6 +19,10 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
 
 (require 'elm-util)
 (require 'elm-compile)
@@ -32,3 +43,5 @@
     (browse-url (concat "file:///" path-html))))
   
 (provide 'elm-preview)
+
+;;; elm-preview.el ends here

--- a/elm-repl.el
+++ b/elm-repl.el
@@ -1,3 +1,10 @@
+;;; elm-repl.el --- Run Elm repl
+
+;; Copyright (C) 2013, 2014  Joseph Collard
+
+;; Author: Joseph Collard
+;; URL: https://github.com/jcollard/elm-mode
+
 ;; This file is not part of GNU Emacs.
 
 ;; This file is free software; you can redistribute it and/or modify
@@ -12,6 +19,10 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
 
 (require 'comint)
 (require 'elm-util)
@@ -86,3 +97,5 @@
 ;; it was echoed in the process buffer
 
 (provide 'elm-repl)
+
+;;; elm-repl.el ends here

--- a/elm-string.el
+++ b/elm-string.el
@@ -1,3 +1,29 @@
+;;; elm-string.el --- String functions used by Elm mode modules
+
+;; Copyright (C) 2013, 2014  Joseph Collard
+
+;; Author: Joseph Collard
+;; URL: https://github.com/jcollard/elm-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Code:
+
 ;;;###autoload
 (defun elm-trim (string)
   (replace-regexp-in-string
@@ -21,3 +47,5 @@
 (defun elm-string ())
 
 (provide 'elm-string)
+
+;;; elm-string.el ends here

--- a/elm-util.el
+++ b/elm-util.el
@@ -1,3 +1,10 @@
+;;; elm-utils.el --- General utility functions used by Elm mode modules
+
+;; Copyright (C) 2013, 2014  Joseph Collard
+
+;; Author: Joseph Collard
+;; URL: https://github.com/jcollard/elm-mode
+
 ;; This file is not part of GNU Emacs.
 
 ;; This file is free software; you can redistribute it and/or modify
@@ -13,9 +20,13 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+;;; Commentary:
+
 ;; Provides useful utility functions
 
 ;; TODO: should be based on the OS.
+
+;;; Code:
 (defvar directory-seperator 
   "/")
 
@@ -119,3 +130,5 @@
 
 
 (provide 'elm-util)
+
+;;; elm-util.el ends here


### PR DESCRIPTION
Hi, I plan to add this to [MELPA](http://melpa.milkbox.net/). This commit makes `elm-mode` installable with `package.el`.
- Add package description (Feel free to change description if desired.)
- Add footer line
- Add Commentary section
- Add Code section
- Add licence

For information about this fix, See following GNU Emacs Manual:
- [Simple-Packages](http://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html)
- [Library-Headers](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html)

(Tip: if you enable auto-insert-mode, Emacs will offer to insert the standard elisp boilerplate when you create a new
.el file.)

Cheers,

-Yasuyuki
