### PR TITLE
Ad autoload-cookie to elm-mode

### DIFF
--- a/elm-mode.el
+++ b/elm-mode.el
@@ -39,6 +39,7 @@
 (add-to-list 'auto-mode-alist '("\\.elm\\'" . elm-mode))
 
 
+;;;###autoload
 (defun elm-mode ()
   "Major mode for editing Elm source code"
   (interactive)


### PR DESCRIPTION
This commit ensures that users who have installed `elm-mode` from MELPA will be able to use the code without explicitly requiring the library first.
