### PR TITLE
Add flag for Javascript-only compile

### DIFF
--- a/elm-compile.el
+++ b/elm-compile.el
@@ -45,6 +45,12 @@
 (defun get-elm-cache-dir ()
   (if elm-cache-dir (concat " --cache-dir=" elm-cache-dir) ""))
 
+(defvar elm-only-js
+  nil)
+
+(defun et-elm-only-js ()
+  (if elm-js-only " --only-js" ""))
+
 (defvar elm-compiler
   "elm")
 
@@ -52,7 +58,8 @@
   (let* ((runtime (get-elm-runtime))
 	 (build (get-elm-build-dir))
 	 (cache (get-elm-cache-dir))
-	 (ls (list elm-compiler " --make" runtime build cache " " file)))
+	 (js-only (get-elm-js-only))
+	 (ls (list elm-compiler " --make" runtime build cache js-only " " file)))
     (reduce 'concat ls)))
 
 (defun elm-compile (file)


### PR DESCRIPTION
Not the best at Emacs Lisp, not sure if this is going to break preview behaviour because it depends on an an HTML file being generated or anything.
