### PR TITLE
fix elm-syntax-propertize so forward-word & co work inside comments

### DIFF
--- a/elm-font-lock.el
+++ b/elm-font-lock.el
@@ -49,7 +49,7 @@
   (goto-char start)
   (funcall
    (syntax-propertize-rules
-           ("^[[:space:]]*\\(--.*\\)\\(
+           ("^[[:space:]]*\\(--\\).*\\(
 \\)"
             (1 "< b")
             (2 "> b")


### PR DESCRIPTION
'elm-syntax-propertize used to mark the whole of a single-line comment,
not just the "--" part, as representing a comment-start sequence. this
caused forward-word (M-f), kill-word (M-d), etc. to skip past
single-line comments entirely.
