### PR TITLE
Revert "Default index of elm-indent-cycle is now 1 instead of 0 when …

### DIFF
--- a/elm-indent.el
+++ b/elm-indent.el
@@ -1264,10 +1264,8 @@ We stay in the cycle as long as the TAB key is pressed."
       (unless (and (eq last-command this-command)
                    (eq bol (car elm-indent-last-info)))
         (save-excursion
-          (let* ((li (elm-indent-indentation-info))
-                 (default-index (if (> (length li) 1) 1 0)))
-            (setq elm-indent-last-info
-                  (list bol li default-index 0)))))
+          (setq elm-indent-last-info
+                (list bol (elm-indent-indentation-info) 0 0))))
 
       (let* ((il (nth 1 elm-indent-last-info))
              (index (nth 2 elm-indent-last-info))


### PR DESCRIPTION
Reverts jcollard/elm-mode#22

Seems to cause some tab-stop issues.