### PR TITLE
Highlight delimiters of multiline lists and records for better scanability

### DIFF
--- a/elm-font-lock.el
+++ b/elm-font-lock.el
@@ -25,6 +25,21 @@
 ;;; Code:
 (require 'font-lock)
 
+(defgroup elm-font-lock nil
+  "Font locking for Elm code."
+  :group 'faces)
+
+(defface elm-font-lock-multiline-list-delimiters
+  '((t :inherit font-lock-keyword-face))
+  "The default face used to highlight brackets and commas in multiline lists."
+  :group 'elm-font-lock)
+
+(defcustom elm-font-lock-multiline-list-delimiters-face 'elm-font-lock-multiline-list-delimiters
+  "The face used to highlight brackets and commas in multilist lists. To disable this highlighting, set this to nil."
+  :type '(choice (const nil)
+                 face)
+  :group 'elm-font-lock)
+
 (defconst elm--keywords
   '("let" "case" "in" "if" "of" "then" "else" "otherwise"
     "module" "import" "as" "exposing"  "type" "where"
@@ -71,10 +86,52 @@
   (cons elm--regexp-type font-lock-type-face)
   "Highlighting for module names and types.")
 
+(defconst elm--regexp-multiline-list-comma-closing-brackets
+  (concat "^[[:space:]]*" (regexp-opt '("," "]" "}") t))
+  "A regular expression representing commas and closing brackets in multiline lists and records.")
+
+(defconst elm--font-lock-multiline-list-comma-closing-brackets
+  (cons elm--regexp-multiline-list-comma-closing-brackets '(1 elm-font-lock-multiline-list-delimiters-face))
+  "Highlighting for commas and closing brackets in multiline lists and records.")
+
+(defun elm--match-multiline-list-opening-bracket (limit)
+  "Highlighting search function for opening brackets in multiline lists and records. Also highlights opening brackets without a matching bracket."
+  (when (elm--search-forward-opening-bracket limit)
+    (let ((opening (point))
+          (eol (line-end-position))
+          (closing (elm--search-forward-closing-bracket)))
+      (if (or (= closing opening) (> closing eol))
+          (progn
+            (set-match-data (match-data))
+            (goto-char (+ 1 opening))
+            t)
+        (elm--match-multiline-list-opening-bracket limit)))))
+
+(defun elm--search-forward-opening-bracket (limit)
+  "Go to the next opening bracket."
+  (if (search-forward-regexp (regexp-opt '("[" "{")) limit t)
+      (progn
+        (backward-char)
+        t)))
+
+(defun elm--search-forward-closing-bracket ()
+  "Go to the next matching bracket, assuming that the cursor is on an opening bracket."
+  (ignore-errors
+    (save-match-data
+      (forward-sexp)))
+  (point))
+
+(defconst elm--font-lock-multiline-list-opening-brackets
+  '(elm--match-multiline-list-opening-bracket (0 elm-font-lock-multiline-list-delimiters-face))
+  "Highlighting for opening brackets in multiline lists and records.")
+
 (defconst elm--font-lock-highlighting
   (list (list elm--font-lock-keywords
               elm--font-lock-functions
-              elm--font-lock-types) nil nil))
+              elm--font-lock-types
+              elm--font-lock-multiline-list-comma-closing-brackets
+              elm--font-lock-multiline-list-opening-brackets)
+        nil nil))
 
 (defun turn-on-elm-font-lock ()
   "Turn on Elm font lock."


### PR DESCRIPTION
[The style guide](http://elm-lang.org/docs/style-guide#types) favors comma-first delimiting for multiline lists and records. It has advantages in ease of editing and diffing, but I've found it to visually crammed and a little difficult to scan (although I'm familiar with the style from [NPM's comma first principle](https://docs.npmjs.com/misc/coding-style#comma-first)).

This patch makes the delimiters visually distinct from the content of the list/record:

### before

<img width="215" alt="test_elm" src="https://cloud.githubusercontent.com/assets/21108/9811216/a990cde8-582a-11e5-9226-7357e9e91ef3.png">

### after

<img width="217" alt="test_elm" src="https://cloud.githubusercontent.com/assets/21108/9811220/b0207d66-582a-11e5-904d-2011f714844f.png">

(theme: monokai)

Suggestions/oppositions?