### PR TITLE
fix a couple of problems with company backend

### DIFF
--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -580,6 +580,7 @@ Runs `elm-reactor' first."
            (end (match-end 0)))
       (s-trim (buffer-substring-no-properties beg end)))))
 
+
 (defun elm-oracle--completion-namelist (completions)
   "Extract a list of identifier names from the COMPLETIONS alists."
   (-map (lambda (candidate)
@@ -694,14 +695,17 @@ Add this function to your `elm-mode-hook'."
 (defun company-elm (command &optional arg &rest ignored)
   "Set up a company backend for elm."
   (interactive (list 'interactive))
-  (let* ((prefix (elm-oracle--completion-prefix-at-point))
-         (completions (elm-oracle--get-completions-cached prefix)))
-    (case command
-      (interactive (company-begin-backend 'company-elm-backend))
-      (prefix prefix)
-      (doc-buffer (elm-oracle--completion-docbuffer completions arg))
-      (candidates (elm-oracle--completion-namelist completions))
-      (meta (elm-oracle--completion-signature completions arg)))))
+  (case command
+    (init t)
+    (interactive (company-begin-backend 'company-elm))
+    (t
+     (let* ((prefix (elm-oracle--completion-prefix-at-point))
+            (completions (elm-oracle--get-completions-cached prefix)))
+       (case command
+         (prefix prefix)
+         (doc-buffer (elm-oracle--completion-docbuffer completions arg))
+         (candidates (elm-oracle--completion-namelist completions))
+         (meta (elm-oracle--completion-signature completions arg)))))))
 
 
 (provide 'elm-interactive)


### PR DESCRIPTION
The interactive use of company-elm was broken, it had an old function reference, changed that.

The backend was running `elm-oracle--completion-prefix-at-point` for every command which caused init to crash when opening an empty file. Did a more exhaustive case match and reorganised the code to get prefix/completions only when asked for them.