### PR TITLE
Allow for a custom main file to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ file.
 | ---------------------- | --------------------------------------------------------------------------------- |
 | <kbd>C-c C-c</kbd>     | Compile the current buffer.                                                       |
 | <kbd>C-u C-c C-c</kbd> | Compile the current buffer, specifying the output file.                           |
-| <kbd>C-c M-c</kbd>     | Compile the <code>Main.elm</code> file.                                           |
-| <kbd>C-u C-c M-c</kbd> | Compile the <code>Main.elm</code> file, specifying the output file.               |
+| <kbd>C-c M-c</kbd>     | Compile the main elm file.                                           |
+| <kbd>C-u C-c M-c</kbd> | Compile the main elm file, specifying the output file.               |
 | <kbd>C-c C-a</kbd>     | Add missing type annotations to the current buffer.                               |
 | <kbd>C-u C-c C-a</kbd> | Add missing type annotations to the current buffer, prompting before each change. |
 | <kbd>C-c C-r</kbd>     | Clean up imports in the current buffer.                                           |
@@ -92,8 +92,8 @@ file.
 | ---------------------- | ------------------------------------------------------------------ |
 | <kbd>C-c C-n</kbd>     | Preview the current buffer in a browser.                           |
 | <kbd>C-u C-c C-n</kbd> | Preview the current buffer in a browser in debug mode.             |
-| <kbd>C-c C-m</kbd>     | Preview the <code>Main.elm</code> file in a browser.               |
-| <kbd>C-u C-c C-m</kbd> | Preview the <code>Main.elm</code> file in a browser in debug mode. |
+| <kbd>C-c C-m</kbd>     | Preview the main elm file in a browser.               |
+| <kbd>C-u C-c C-m</kbd> | Preview the main elm file in a browser in debug mode. |
 
 #### `elm-package`
 

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -326,7 +326,7 @@ Runs `elm-reactor' first."
 
 ;;;###autoload
 (defun elm-preview-main (debug)
-  "Preview the Main.elm file using Elm reactor (in debug mode if DEBUG is truthy)."
+  "Preview the main elm file using Elm reactor (in debug mode if DEBUG is truthy)."
   (interactive "P")
   (elm-reactor--browse (elm--find-main-file) debug))
 
@@ -385,7 +385,7 @@ Runs `elm-reactor' first."
 
 ;;;###autoload
 (defun elm-compile-main (&optional output)
-  "Compile the Main.elm file into OUTPUT."
+  "Compile the main elm file into OUTPUT."
   (interactive
    (when current-prefix-arg
      (list (read-file-name "Output to: "))))

--- a/elm-util.el
+++ b/elm-util.el
@@ -23,6 +23,11 @@
 
 ;;; Commentary:
 ;;; Code:
+(defcustom elm-main "Main.elm"
+  "Allows for a custom main file to be specified."
+  :group 'elm-util
+  :type 'string)
+
 (require 'f)
 (require 'json)
 (require 'let-alist)
@@ -107,12 +112,12 @@ Relies on `haskell-mode' stuff."
     (json-read-file dep-file)))
 
 (defun elm--find-main-file ()
-  "Find the Main.elm file."
+  "Find the main elm file."
   (let-alist (elm--read-dependency-file)
     (let ((source-dir (aref .source-directories 0)))
       (if (equal "." source-dir)
-          "Main.elm"
-        (f-join source-dir "Main.elm")))))
+          elm-main
+        (f-join source-dir elm-main)))))
 
 (defun elm--shell-and-command ()
   "Determine the appropriate 'and' command for the current shell.


### PR DESCRIPTION
This patch allows for a custom main file to be specified by customizing `elm-main` (for example I am using `App.elm`).