### PR TITLE
Improving next-error navigation.

### DIFF
--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -90,11 +90,10 @@
   :group 'elm)
 
 (defvar elm-compile-error-regexp-alist-alist
-  '((elm-file "-- [^-]+ -+ \\(.+\\)$" 1 nil)
-    (elm-line "^\\([0-9]+\\)|" nil 1))
-  "Regexps to match Elm compiler errors in compilation buffer.")
+  '((elm-locus "-- [^-]+ -+ \\(.+\\):\\([0-9]+\\):\\([0-9]+\\)$" 1 2 3))
+  "Regexp to match Elm compiler errors in compilation buffer.")
 
-(defvar elm-compile-error-regexp-alist '(elm-line elm-file))
+(defvar elm-compile-error-regexp-alist '(elm-locus))
 
 (dolist (alist elm-compile-error-regexp-alist-alist)
   (add-to-list 'compilation-error-regexp-alist-alist alist))


### PR DESCRIPTION
Pending a request to display the line number and column number from the elm-compiler/elm-make, this change will improve elm-mode's next-error function in compilation mode.

Please see:
https://github.com/elm-lang/elm-make/pull/113
https://github.com/elm-lang/elm-compiler/pull/1462