### PR TITLE
Save the buffer in elm-repl-load

### DIFF
--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -286,6 +286,7 @@ Changes the current root directory to be the directory with the closest
 package json if one exists otherwise sets it to be the working directory
 of the file specified."
   (interactive)
+  (save-buffer)
   (let ((import-statement (elm--build-import-statement)))
     (run-elm-interactive)
     (elm-interactive--send-command ":reset\n")


### PR DESCRIPTION
To someone used to other interactive modes, it's surprising that `elm-repl-load` doesn't save the current buffer before loading. It means an extra command needs to be run whenever incrementally making changes, and it makes it easier for confusion to arise about the save state of a file.