### PR TITLE
Don't modify the kill-ring in elm-sort-imports

### DIFF
--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -500,7 +500,7 @@ Import consists of the word \"import\", real package name, and optional
           (text (buffer-substring-no-properties beg end))
           (imports (mapcar 'first
                            (s-match-strings-all elm-import--pattern text))))
-      (kill-region beg end)
+      (delete-region beg end)
       (insert (s-join "\n" (sort imports 'string<))))))
 
 ;;;###autoload


### PR DESCRIPTION
Use `delete-region` instead of `kill-region` in `elm-sort-imports`.

Consider the following sequence of commands:

1. kill some text in buffer A
2. save buffer A
3. switch to buffer B
4. yank text from kill-ring

Prior to this change, if a user had enabled `elm-sort-imports-on-save`, then when yanking text in step 4, they would not get the text killed in step 1, but rather the import list killed by `elm-sort-imports`.