### PR TITLE
Avoid modifying the buffer if imports are already sorted

### DIFF
--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -497,11 +497,13 @@ Import consists of the word \"import\", real package name, and optional
     (let* ((beg (point))
           (_ (while (re-search-forward elm-import--pattern nil t)))
           (end (point))
-          (text (buffer-substring-no-properties beg end))
+          (old-imports (buffer-substring-no-properties beg end))
           (imports (mapcar 'first
-                           (s-match-strings-all elm-import--pattern text))))
-      (kill-region beg end)
-      (insert (s-join "\n" (sort imports 'string<))))))
+                           (s-match-strings-all elm-import--pattern old-imports)))
+          (sorted-imports (s-join "\n" (sort imports 'string<))))
+      (unless (string= old-imports sorted-imports)
+        (delete-region beg end)
+        (insert sorted-imports)))))
 
 ;;;###autoload
 (defun elm-compile-add-annotations (&optional prompt)


### PR DESCRIPTION
Current version of `elm-sort-imports` kills the region and inserts sorted imports even if there is nothing to change.

Also includes the change, suggested in #96, as the changes are in the same place.

