### PR TITLE
Interpret ansi-colors in fomatter's error message

### DIFF
--- a/elm-format.el
+++ b/elm-format.el
@@ -37,6 +37,14 @@
   "The name of the `elm-format' command.")
 
 
+(defun elm--display-error (err-file)
+  "Displays the error buffer to the user"
+  (require 'ansi-color)
+  (with-temp-buffer
+    (insert-file-contents err-file nil nil nil t)
+    (ansi-color-apply-on-region (point-min) (point-max))
+    (message "Error: elm-format failed on current buffer.\n\n%s" (buffer-string))))
+
 ;;;###autoload
 (defun elm-mode-format-buffer ()
   "Apply `elm-format' to the current buffer."
@@ -60,9 +68,7 @@
                           "--yes"))))
 
     (if (/= retcode 0)
-        (with-temp-buffer
-          (insert-file-contents err-file nil nil nil t)
-          (message "Error: elm-format failed on current buffer.\n\n%s" (buffer-string)))
+        (elm--display-error err-file)
       (insert-file-contents out-file nil nil nil t)
       (goto-char (point-min))
       (forward-line (1- line))


### PR DESCRIPTION
Current versions of elm-format use ANSI codes to display colored output.

Before this change, the raw output of elm-format was being displayed to the
user using the `message` function, which resulted in escape sequences being
shown:

<img width="654" alt="screen shot 2017-04-25 at 11 36 08" src="https://cloud.githubusercontent.com/assets/753421/25394304/b41fa866-29ab-11e7-8ebd-c581e744e765.png">

This commit uses `ansi-color` to interpret color codes when reading the output
of elm-format, so that when the error message is displayed we only show
meaningful text:

<img width="586" alt="screen shot 2017-04-25 at 11 41 15" src="https://cloud.githubusercontent.com/assets/753421/25394537/434d2838-29ac-11e7-8810-4f5091119740.png">

This is related to #98. Fixes the problem for the formatter output but not for the compilation buffer (since we use different ways of displaying output for each case)