### PR TITLE
fix elm-mode-generate-tags in Aquamacs Emacs

### DIFF
--- a/elm-tags.el
+++ b/elm-tags.el
@@ -61,7 +61,7 @@
                               find-command))
            (etags-command (concat
                            exclude-command
-                           " | etags --language=none --regex=@" elm-tags-regexps " -")))
+                           " | etags --language=none --regex=@\"" elm-tags-regexps "\" -")))
       (call-process-shell-command (concat etags-command "&") nil 0))))
 
 


### PR DESCRIPTION
elm-mode-generate-tags does not work when the abosolute
path of elm-mode package contains blank space.
eg: /Users/steve/Library/Preferences/Aquamacs Emacs/Packages/elpa/elm-mode-20170322.1347/
Quoting elm-tags-regexps params makes it work.