### PR TITLE
Allow jumping back and forth between code and repl with "C-c C-z"

### DIFF
--- a/elm-mode.el
+++ b/elm-mode.el
@@ -4,7 +4,7 @@
 ;; Copyright (C) 2015, 2016  Bogdan Popa
 
 ;; Author: Joseph Collard
-;; Package-Requires: ((f "0.17") (let-alist "1.0.4") (s "1.7.0") (emacs "24"))
+;; Package-Requires: ((f "0.17") (let-alist "1.0.4") (s "1.7.0") (emacs "24.4"))
 ;; URL: https://github.com/jcollard/elm-mode
 
 ;; This file is not part of GNU Emacs.

--- a/elm-mode.el
+++ b/elm-mode.el
@@ -60,6 +60,7 @@
     (define-key map "\C-c\C-l" 'elm-repl-load)
     (define-key map "\C-c\C-p" 'elm-repl-push)
     (define-key map "\C-c\C-e" 'elm-repl-push-decl)
+    (define-key map "\C-c\C-z" 'run-elm-interactive)
     (define-key map "\C-c\C-a" 'elm-compile-add-annotations)
     (define-key map "\C-c\C-r" 'elm-compile-clean-imports)
     (define-key map "\C-c\C-c" 'elm-compile-buffer)


### PR DESCRIPTION
This convenient symmetrical binding is idiomatic and used in many other major modes which support REPLs, e.g. `haskell-mode` & `clojure-mode`.