### PR TITLE
new customizable variable `elm--get-decl/flash-duration'

### DIFF
--- a/elm-util.el
+++ b/elm-util.el
@@ -36,6 +36,11 @@
   :type 'string
   :group 'elm-util)
 
+(defcustom elm--get-decl/flash-duration 0.40
+  "Time in seconds the declaration found by `elm--get-decl' will be highlighted."
+  :type 'number
+  :group 'elm-util)
+
 (defconst elm-package-json
   "elm-package.json"
   "The name of the package JSON configuration file.")
@@ -63,7 +68,7 @@ Relies on `haskell-mode' stuff."
            (lines (split-string raw-decl "\n"))
            (first-line (car lines)))
 
-      (inferior-haskell-flash-decl start end)
+      (inferior-haskell-flash-decl start end elm--get-decl/flash-duration)
       (if (string-match-p "^[a-z].*:" first-line)
           (cdr lines)
         lines))))

--- a/elm-util.el
+++ b/elm-util.el
@@ -36,8 +36,8 @@
   :type 'string
   :group 'elm-util)
 
-(defcustom elm--get-decl/flash-duration 0.40
-  "Time in seconds the declaration found by `elm--get-decl' will be highlighted."
+(defcustom elm-flash-duration 0.40
+  "Time in seconds for which declarations will be highlighted when applicable."
   :type 'number
   :group 'elm-util)
 
@@ -68,7 +68,7 @@ Relies on `haskell-mode' stuff."
            (lines (split-string raw-decl "\n"))
            (first-line (car lines)))
 
-      (inferior-haskell-flash-decl start end elm--get-decl/flash-duration)
+      (inferior-haskell-flash-decl start end elm-flash-duration)
       (if (string-match-p "^[a-z].*:" first-line)
           (cdr lines)
         lines))))


### PR DESCRIPTION
Hello

I've introduced a small new variable to be able customize the flash duration in `elm--get-decl`.

This is the first one of 3 changes which follow.

Cheers,
Berkan