### PR TITLE
elm-repl-push/no-switch

### DIFF
--- a/elm-util.el
+++ b/elm-util.el
@@ -36,6 +36,11 @@
   :type 'string
   :group 'elm-util)
 
+(defcustom elm--get-decl/flash-duration 0.40
+  "Time in seconds the declaration found by `elm--get-decl' will be highlighted."
+  :type 'number
+  :group 'elm-util)
+
 (defconst elm-package-json
   "elm-package.json"
   "The name of the package JSON configuration file.")
@@ -63,7 +68,7 @@ Relies on `haskell-mode' stuff."
            (lines (split-string raw-decl "\n"))
            (first-line (car lines)))
 
-      (inferior-haskell-flash-decl start end)
+      (inferior-haskell-flash-decl start end elm--get-decl/flash-duration)
       (if (string-match-p "^[a-z].*:" first-line)
           (cdr lines)
         lines))))

--- a/elm-util.el
+++ b/elm-util.el
@@ -54,7 +54,7 @@
     (buffer-substring-no-properties (match-beginning 1) (match-end 1))))
 
 (defun elm--get-decl ()
-  "Return the current declaration.
+  "Return the current declaration as a list of lines, together with the beginning and end of its region.
 
 Relies on `haskell-mode' stuff."
   (unless (fboundp #'haskell-ds-backward-decl)
@@ -62,16 +62,30 @@ Relies on `haskell-mode' stuff."
 
   (save-excursion
     (goto-char (1+ (point)))
-    (let* ((start (or (haskell-ds-backward-decl) (point-min)))
-           (end (or (haskell-ds-forward-decl) (point-max)))
-           (raw-decl (s-trim-right (buffer-substring start end)))
+    (let* ((decl-beg (or (haskell-ds-backward-decl) (point-min)))
+           (decl-end (or (haskell-ds-forward-decl) (point-max)))
+           (raw-decl (s-trim-right (buffer-substring decl-beg decl-end)))
            (lines (split-string raw-decl "\n"))
            (first-line (car lines)))
 
-      (inferior-haskell-flash-decl start end elm--get-decl/flash-duration)
-      (if (string-match-p "^[a-z].*:" first-line)
-          (cdr lines)
-        lines))))
+      (inferior-haskell-flash-decl decl-beg decl-end elm--get-decl-flash-duration)
+
+      (cl-values
+       (if (string-match-p "^[a-z].*:" first-line)
+           (cdr lines)
+         lines)
+       decl-beg
+       decl-end))))
+
+(defun elm--get-region (beg end)
+  "Return the region between BEG and END as a list of lines."
+  (let* ((to-push (buffer-substring-no-properties beg end))
+         (lines (split-string (s-trim-right to-push) "\n")))
+    lines))
+
+(defun elm--print-result (result &rest r)
+  "Display the first line of RESULT in the echo area."
+  (princ (car (split-string result "\n")) ))
 
 (defun elm--build-import-statement ()
   "Generate a statement that will import the current module."
@@ -130,6 +144,11 @@ cases."
     (pcase executable
       ("fish" "; and ")
       (_ " && "))))
+
+
+(defmacro xor (a b)
+  `(if ,a (not ,b) ,b))
+
 
 (provide 'elm-util)
 ;;; elm-util.el ends here


### PR DESCRIPTION
This change allows `elm-repl-push` and `elm-repl-push-decl` to work without switching to the REPL buffer.

The use-case I'm addressing is to evaluate code directly from a source code buffer, with minimum disruptions.

The details of the change are:

* `elm-repl-push` & `elm-repl-push-decl` accept a universal argument which controls whether or not to switch to the REPL buffer after the push. 

  The default behaviour is:
   * if the universal argument is not given or `nil`, switch to the REPL buffer
   * if the universal argument is `non-nil`, stay in the current buffer after the push

* Setting the variable `elm-interactive-flip-arg-switch-behaviour` to `non-nil` reverses the default behaviour above. 

* After a push, functions in `elm-interactive-after-push-hook` are run with the result of the last push
    * Currently this hook contains `elm--print-result` which prints the first line of a possibly multi-line string in the echo area (this is so that the echo area doesn't grow and create an unnecessary visual distraction)
