### PR TITLE
code-fixes elm-compile-{clean-imports,add-annotations} work on unsaved buffer contents

### DIFF
--- a/elm-util.el
+++ b/elm-util.el
@@ -126,5 +126,16 @@ cases."
       ("fish" "; and ")
       (_ " && "))))
 
+
+(defmacro xor (a b)
+  `(if ,a (not ,b) ,b))
+
+(defmacro with-suppressed-message (&rest body)
+  "Suppress new messages temporarily in the echo area and the `*Messages*' buffer while BODY is evaluated."
+  (declare (indent 0))
+  (let ((message-log-max nil))
+    `(with-temp-message (or (current-message) "") ,@body)))
+
+
 (provide 'elm-util)
 ;;; elm-util.el ends here


### PR DESCRIPTION
I wanted to be able to add annotations and clean imports without first having to save the buffer.

For example: if I start writing a new function and want `elm-make` to automatically add its annotation, I need to remember to save the file first. I rather I didn't have to do that (nor be prompted to do that).

With this change, `elm-compile-clean-imports` and `elm-compile-add-annotations` work on unsaved buffer contents:

* `elm-compile--temporary' compiles the current buffer contents (and not the saved file)

Berkan