### PR TITLE
Support non numeric return values for elm-format's call-process

### DIFF
--- a/elm-format.el
+++ b/elm-format.el
@@ -73,7 +73,7 @@
                                 "--output" out-file
                                 "--elm-version" version
                                 "--yes"))))
-          (if (/= retcode 0)
+          (if (not (eq retcode 0))
               (elm-format--display-error err-file)
             (insert-file-contents out-file nil nil nil t)))
       (delete-file in-file)


### PR DESCRIPTION
According to call-process's documentation:

```
If DESTINATION is 0, ‘call-process’ returns immediately with value nil.
Otherwise it waits for PROGRAM to terminate
and returns a numeric exit status or a signal description string.
If you quit, the process is killed with SIGINT, or SIGKILL if you quit again.
```

Checking for equality with `/=` caused the function to fail in cases where
`retcode` was a string. That's probably not very common, but can happen.

Yesterday I updated some homebrew stuff and elm-format failed when trying
to use a dynamically linked library. In this case, `call-process` returned a
string, which caused a runtime error when checking for that exit code.

This manifested itself in me not being able to save any elm file (having
`elm-format-on-save` enabled), which was not very easy to track down :-)