### PR TITLE
Make elm-format's error handling less intrusive

### DIFF
--- a/elm-format.el
+++ b/elm-format.el
@@ -46,8 +46,7 @@
   "Replaces the current buffer's contents with the output of a successful call to elm-format."
   (let ((error-buffer (get-buffer error-buffer-name)))
     (when error-buffer
-      (save-current-buffer
-        (set-buffer error-buffer)
+      (with-current-buffer error-buffer
         (read-only-mode 0)
         (erase-buffer)
         (insert "elm-format applied successfully.")
@@ -64,8 +63,7 @@
   Otherwise, just displays a message informing that the call failed."
 
   (let ((error-buffer (get-buffer-create error-buffer-name)))
-    (save-current-buffer
-      (set-buffer error-buffer)
+    (with-current-buffer error-buffer
       (read-only-mode 0)
       (insert-file-contents err-file nil nil nil t)
       (ansi-color-apply-on-region (point-min) (point-max))

--- a/elm-format.el
+++ b/elm-format.el
@@ -42,18 +42,43 @@
   :group 'elm-format
   :type 'string)
 
+(defun elm-format--handle-success (out-file error-buffer-name is-call-interactive)
+  "Replaces the current buffer's contents with the output of a successful call to elm-format."
+  (let ((error-buffer (get-buffer error-buffer-name)))
+    (when error-buffer
+      (save-current-buffer
+        (set-buffer error-buffer)
+        (read-only-mode 0)
+        (erase-buffer)
+        (insert "elm-format applied successfully.")
+        (read-only-mode 1)))
 
-(defun elm-format--display-error (err-file)
-  "Displays the error in file ERR-FILE to the user."
-  (with-temp-buffer
-    (insert-file-contents err-file nil nil nil t)
-    (ansi-color-apply-on-region (point-min) (point-max))
-    (message "Error: elm-format failed on current buffer.\n\n%s" (buffer-string))))
+    (insert-file-contents out-file nil nil nil t)
+
+    (when is-call-interactive
+      (message "elm-format applied"))))
+
+(defun elm-format--handle-error (err-file error-buffer-name is-call-interactive)
+  "Handles error for calls to elm-format.
+  If elm-format was run interactively by the user, displays a read-only buffer with the error.
+  Otherwise, just displays a message informing that the call failed."
+
+  (let ((error-buffer (get-buffer-create error-buffer-name)))
+    (save-current-buffer
+      (set-buffer error-buffer)
+      (read-only-mode 0)
+      (insert-file-contents err-file nil nil nil t)
+      (ansi-color-apply-on-region (point-min) (point-max))
+      (read-only-mode t))
+
+    (if is-call-interactive
+        (display-buffer error-buffer)
+      (message (concat "elm-format failed: see " error-buffer-name)))))
 
 ;;;###autoload
-(defun elm-mode-format-buffer ()
+(defun elm-mode-format-buffer (&optional is-call-interactive)
   "Apply `elm-format' to the current buffer."
-  (interactive)
+  (interactive "p")
   (let* (;; elm-format requires that the file have a .elm extension
          (in-file (make-temp-file "elm-format" nil ".elm"))
          (err-file (make-temp-file "elm-format"))
@@ -64,6 +89,7 @@
     (unwind-protect
         (let* ((command elm-format-command)
                (version elm-format-elm-version)
+               (error-buffer-name "*elm-format errors*")
                (retcode
                 (with-temp-buffer
                   (call-process command
@@ -74,8 +100,8 @@
                                 "--elm-version" version
                                 "--yes"))))
           (if (not (eq retcode 0))
-              (elm-format--display-error err-file)
-            (insert-file-contents out-file nil nil nil t)))
+              (elm-format--handle-error err-file error-buffer-name is-call-interactive)
+            (elm-format--handle-success out-file error-buffer-name is-call-interactive)))
       (delete-file in-file)
       (delete-file err-file)
       (delete-file out-file))))


### PR DESCRIPTION
When elm-format fails:
  - output is displayed in a well known `*elm-format errors*` buffer
  - if the user is calling the elm-format command interactively, display the
    error buffer
  - if elm-format is being called non-interactively (for example, when using
    elm-format-on-save) just display a message telling the user that something
    happened, suggesting to look at the error buffer.

The error buffer is cleared when elm-format succeeds, to avoid confusion.

Fixes jcollard/elm-mode#117