### PR TITLE
Improved auto completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ the following dependencies are available:
 * [f](https://github.com/rejeep/f.el)
 * [let-alist](https://elpa.gnu.org/packages/let-alist.html)
 * [s](https://github.com/magnars/s.el)
+* [dash](https://github.com/magnars/dash.el)
 
 This package assumes you are runing Emacs 24 or later.
 

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -821,7 +821,7 @@ Import consists of the word \"import\", real package name, and optional
     "Reads imports from given buffer and returns an alist containing imports and their aliases"
     (let ((imports (s-match-strings-all elm-import--pattern (buffer->string buffer))))
       (mapcar #'(lambda (x) (extract-alias
-                             (s-split-words (strip-properties (first x))))) imports)))
+                             (s-split "[ \n\t]+" (strip-properties (first x))))) imports)))
 
   (defun elm-imports--store (buffer)
     "Reads imports from buffer and stores them"

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -164,7 +164,7 @@
   :group 'elm)
 
 (defconst elm-oracle--pattern
-  "\\(?:[^A-Za-z0-9_.']\\)\\(\\(?:[A-Za-z_][A-Za-z0-9_']*[.]\\)?[A-Za-z0-9_']*\\)"
+  "\\(?:[^A-Za-z0-9_.']\\)\\(\\(?:[A-Za-z_][A-Za-z0-9_']*[.]\\)*[A-Za-z0-9_']*\\)"
   "The prefix pattern used for completion.")
 
 (defvar elm-oracle--completion-cache (make-hash-table :test #'equal)

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -803,6 +803,20 @@ Import consists of the word \"import\", real package name, and optional
       (insert (concat statement "\n"))))
   (elm-sort-imports))
 
+(let* ((files-imports (make-hash-table :test 'equal))
+       (get-file-imports
+        #'(lambda (file) (let ((imports (gethash file files-imports)))
+                           (if imports imports
+                             (setf (gethash file files-imports)
+                                   (make-hash-table :test 'equal)))))))
+  (progn
+    (defun elm-imports--add (buf module alias)
+      (let ((imports (funcall get-file-imports buf)))
+        (setf (gethash module imports) alias)))
+    (defun elm-imports--get (buf module)
+      (gethash module (funcall get-file-imports buf)))
+    (defun elm-imports--reset (buf)
+      (setf (gethash buf files-imports) (make-hash-table :test 'equal)))))
 
 (defun elm-documentation--show (documentation)
   "Show DOCUMENTATION in a help buffer."

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -26,6 +26,7 @@
 (require 'comint)
 (require 'compile)
 (require 'cl-lib)
+(require 'dash)
 (require 'elm-font-lock)
 (require 'elm-util)
 (require 'f)

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -219,7 +219,7 @@
   "Wait until PROC sends us a prompt or TIMEOUT.
 The process PROC should be associated to a comint buffer.
 
-Stolen from haskell-mode."
+Stolen from ‘haskell-mode’."
   (with-current-buffer (process-buffer proc)
     (while (progn
              (goto-char comint-last-input-end)
@@ -801,7 +801,7 @@ Import consists of the word \"import\", real package name, and optional
   (elm-sort-imports))
 
 (defun elm-imports--list (buffer)
-  "Find all imports in the current buffer.
+  "Find all imports in the current BUFFER.
 Return a list of pairs of (FULL_NAME . NAME)."
   (with-current-buffer buffer
     (save-excursion
@@ -817,7 +817,7 @@ Return a list of pairs of (FULL_NAME . NAME)."
           matches)))))
 
 (defun elm-imports--store (buffer)
-  "Reads imports from buffer and stores them"
+  "Read imports from BUFFER and store them."
   (progn
     (elm-imports--reset buffer)
     (mapc #'(lambda (import) (elm-imports--add buffer (car import) (cdr import)))
@@ -842,7 +842,7 @@ Return a list of pairs of (FULL_NAME . NAME)."
       (setf (gethash buf files-imports) (make-hash-table :test 'equal)))))
 
 (defun elm-imports--aliased (buffer name full-name)
-  "Translates an exposed function with NAME and qualified name FULL-NAME to its fully qualified form using the alias defined inside the BUFFER"
+  "Use aliases defined inside BUFFER to translate an exposed function with NAME and qualified name FULL-NAME to its aliased and qualified form."
   (let* ((suffix (concat "." name))
          (module-name (s-chop-suffix suffix full-name)))
     (concat (elm-imports--get buffer module-name) suffix)))
@@ -1159,22 +1159,22 @@ Add this function to your `elm-mode-hook'."
       (meta (elm-company--meta arg)))))
 
 (defun elm-company--candidates (prefix &optional callback)
-  "Function providing candidates for company-mode"
+  "Function providing candidates for company-mode for given PREFIX."
   (funcall (if callback callback #'identity)
            (mapcar #' elm-company--make-candidate (elm-oracle--get-candidates prefix))))
 
 (defun elm-company--make-candidate (candidate)
-  "Creates a company-mode completion candidate from a CANDIDATE obtained via elm-oracle"
+  "Create a ‘company-mode’ completion candidate from a CANDIDATE obtained via elm-oracle."
   (let-alist candidate
     (propertize .fullName
                 'signature .signature 'name .fullName 'comment .comment)))
 
 (defun elm-company--signature (candidate)
-  "Returns company signature for CANDIDATE"
+  "Return company signature for CANDIDATE."
   (format " %s" (get-text-property 0 'signature candidate)))
 
 (defun elm-company--meta (candidate)
-  "Returns company meta for CANDIDATE"
+  "Return company meta for CANDIDATE."
   (format "%s : %s"
           (get-text-property 0 'name candidate)
           (get-text-property 0 'signature candidate)))
@@ -1214,11 +1214,11 @@ Add this function to your `elm-mode-hook'."
         (hash-table-values (get-map module oracle-cache))))))
 
 (defun elm-oracle--cache (candidates)
-  "Caches candidates returned by elm-oracle for future use"
+  "Caches CANDIDATES returned by elm-oracle for future use."
   (mapcar #'elm-oracle--cache-store candidates))
 
 (defun elm-oracle--cached-candidates (prefix)
-  "Returns cached elm-oracle completion candidates for given PREFIX"
+  "Return cached elm-oracle completion candidates for given PREFIX."
   (if (> (length prefix) 0)
       (let* ((aliased (elm-oracle--modules))
              ;; "Basics" module is exposed by default, let's parse it
@@ -1247,7 +1247,7 @@ Add this function to your `elm-mode-hook'."
                   (apply #'nconc completions)))))))
 
 (defun elm-oracle--get-candidates (prefix)
-  "Rerturns elm-oracle completion candidates for given PREFIX"
+  "Rerturns elm-oracle completion candidates for given PREFIX."
   (let*
       ((default-directory (elm--find-dependency-file-path))
        (file (or (buffer-file-name) (elm--find-main-file))))
@@ -1262,7 +1262,7 @@ Add this function to your `elm-mode-hook'."
       (or (elm-oracle--cached-candidates prefix) (elm-oracle--run prefix file)))))))
 
 (defun elm-oracle--run (prefix &optional file)
-  "Get completions inside FILE for PREFIX"
+  "Get completions for PREFIX inside FILE."
   (let ((command (s-join " " (list elm-oracle-command
                                    (shell-quote-argument file)
                                    (shell-quote-argument prefix))))

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -808,8 +808,8 @@ Import consists of the word \"import\", real package name, and optional
      (extract-alias (words)
                     (let
                         ((bare-import (car (--split-with
-                                            (not (equal "exposing" it))
-                                            (--drop-while (equal "import" it) words)))))
+                                            (not (s-prefix? "exposing" it))
+                                            (--drop-while (s-prefix? "import" it) words)))))
                       (let ((maybe-aliased
                              (mapcar #'(lambda (lst) (s-join "." lst)) (-split-on "as" bare-import))))
                         (if (eq 1 (length maybe-aliased))

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -803,6 +803,11 @@ Import consists of the word \"import\", real package name, and optional
       (insert (concat statement "\n"))))
   (elm-sort-imports))
 
+(defun elm-imports--read (buffer)
+  (let ((imports (s-match-strings-all elm-import--pattern (buffer->string buffer))))
+    (labels ((strip-properties (s) (substring-no-properties s)))
+    (mapcar #'(lambda (x) (s-split-words (strip-properties (first x)))) imports))))
+
 (let* ((files-imports (make-hash-table :test 'equal))
        (get-file-imports
         #'(lambda (file) (let ((imports (gethash file files-imports)))

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -1102,10 +1102,7 @@ Add this function to your `elm-mode-hook'."
   (when (derived-mode-p 'elm-mode)
     (cl-case command
       (interactive (company-begin-backend 'company-elm))
-      (prefix
-       (let ((prefix (elm-oracle--completion-prefix-at-point)))
-         (when (s-contains? "." prefix)
-           prefix)))
+      (prefix (elm-oracle--completion-prefix-at-point))
       (doc-buffer (elm-oracle--completion-docbuffer arg))
       (candidates (cons :async (apply-partially #'elm-oracle--completion-namelist arg)))
       (annotation (elm-oracle--completion-annotation arg))

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -843,6 +843,11 @@ Import consists of the word \"import\", real package name, and optional
     (defun elm-imports--reset (buf)
       (setf (gethash buf files-imports) (make-hash-table :test 'equal)))))
 
+(defun elm-imports--aliased (buffer name full-name)
+  (let* ((suffix (concat "." name))
+         (module-name (s-chop-suffix suffix full-name)))
+    (elm-imports--get buffer module-name)))
+
 (defun elm-documentation--show (documentation)
   "Show DOCUMENTATION in a help buffer."
   (let-alist documentation
@@ -995,7 +1000,7 @@ Import consists of the word \"import\", real package name, and optional
   "Filter by PREFIX a list of CANDIDATES."
   (cl-remove-if-not (lambda (candidate)
                       (let-alist candidate
-                        (string-prefix-p prefix .fullName)))
+                        (string-prefix-p prefix (elm-imports--aliased (buffer-name) .name .fullName))))
                     candidates))
 
 (defun elm-oracle--get-completions-cached (prefix &optional callback)

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -825,8 +825,10 @@ Import consists of the word \"import\", real package name, and optional
 
   (defun elm-imports--store (buffer)
     "Reads imports from buffer and stores them"
-    (mapc #'(lambda (import) (elm-imports--add buffer (car import) (-last-item import)))
-          (elm-imports--read buffer))))
+    (progn
+      (elm-imports--reset buffer)
+      (mapc #'(lambda (import) (elm-imports--add buffer (car import) (-last-item import)))
+            (elm-imports--read buffer))))
 
 (let* ((files-imports (make-hash-table :test 'equal))
        (get-file-imports
@@ -847,6 +849,11 @@ Import consists of the word \"import\", real package name, and optional
   (let* ((suffix (concat "." name))
          (module-name (s-chop-suffix suffix full-name)))
     (elm-imports--get buffer module-name)))
+
+(add-hook 'elm-mode-hook #'(lambda () (elm-imports--store (buffer-name))))
+(add-hook 'after-save-hook
+          #'(lambda () (when (equal major-mode 'elm-mode)
+                         (elm-imports--store (buffer-name)))))
 
 (defun elm-documentation--show (documentation)
   "Show DOCUMENTATION in a help buffer."

--- a/elm-mode.el
+++ b/elm-mode.el
@@ -4,7 +4,7 @@
 ;; Copyright (C) 2015, 2016  Bogdan Popa
 
 ;; Author: Joseph Collard
-;; Package-Requires: ((f "0.17") (let-alist "1.0.4") (s "1.7.0") (emacs "24.4"))
+;; Package-Requires: ((f "0.17") (let-alist "1.0.4") (s "1.7.0") (emacs "24.4") (dash "2.13.0"))
 ;; URL: https://github.com/jcollard/elm-mode
 
 ;; This file is not part of GNU Emacs.

--- a/elm-util.el
+++ b/elm-util.el
@@ -130,6 +130,9 @@ per the `elm-package-json' variable."
           elm-main-file
         (f-join source-dir elm-main-file)))))
 
+(defun buffer->string (buffer)
+  (with-current-buffer buffer (buffer-string)))
+
 (defun elm--shell-and-command ()
   "Determine the appropriate 'and' command for the current shell.
 


### PR DESCRIPTION
As mentioned in #121, this PR contains an approach where modules' contents are cached in a global cache and aliased imports inside separate (per-file) caches. 

The changes expose a common interface for querying for completion as well as a `company` backend which uses them. 

This leaves some small changes to be made like updating the `ac`-based completion to use this new interface. Also completions for modules `exposing (..)` currently completes a fully qualified name.

I'll also need to document things a bit before they gets merged.