### PR TITLE
Add wrapper function for executables

### DIFF
--- a/elm-format.el
+++ b/elm-format.el
@@ -60,13 +60,13 @@ IS-INTERACTIVE, show a buffer if the formatting fails."
                (error-buffer (get-buffer-create "*elm-format errors*"))
                (command-with-args (funcall
                          elm-command-wrapper-function
-                         (-map (lambda (arg) (shell-quote-argument arg))
-                               (cons (funcall elm-executable-find elm-format-command)
-                                     (list
-                                      in-file
-                                      "--output" out-file
-                                      "--elm-version" version
-                                      "--yes")))))
+                         (mapcar 'shell-quote-argument
+                                 (cons (funcall elm-executable-find elm-format-command)
+                                       (list
+                                        in-file
+                                        "--output" out-file
+                                        "--elm-version" version
+                                        "--yes")))))
                (command (car command-with-args))
                (args (cdr command-with-args))
                (retcode

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -232,7 +232,7 @@ environments such as bundle or NixOS sandboxes."
   (mapcar 'shell-quote-argument
           (funcall
            elm-command-wrapper-function
-           (mapcar 'shell-quote-arugment
+           (mapcar 'shell-quote-argument
                    (cons (funcall elm-executable-find program)
                          args)))))
 
@@ -1124,7 +1124,6 @@ Completions are in the same format as those returned by
   (let ((default-directory (elm--find-dependency-file-path))
         (command (elm-command-wrapper elm-oracle-command (list file prefix)))
         (json-array-type 'list))
-    (message command)
     (seq-uniq
      (json-read-from-string (shell-command-to-string command))
      (lambda (i1 i2)


### PR DESCRIPTION
First off, this is pretty much my first foray into elisp, so please excuse if i made any obvious mistakes.

The reason for this change is that I'd like to use `elm-mode` in combination with `nix-sandbox`. My setup is that I have one `shell.nix` per project that lists all dependencies (including things like `elm-oracle`, `elm-format`, `elm-make`, etc).
The problem is that they are at paths like `/nix/store/w13jlcyg61vlxdd58jjzyifj1pyl3xvy-elm-0.18.0/bin/elm-format` which are not in the normal `$PATH` variable, but only added once you are inside a `nix-shell`.

The approach I took is inspired by the implementation in `flycheck`, and used for `nix-sandbox` at https://github.com/travisbhartwell/nix-emacs/blob/master/README.org#flycheck

What it basically does is, to give users the ability to find executables every time they are needed, instead of only once on emacs startup.

```elisp
  (setq
    elm-command-wrapper-function
      (lambda (command) (apply 'nix-shell-command (nix-current-sandbox) command))
    elm-executable-find
      (lambda (cmd) (nix-executable-find (nix-current-sandbox) cmd)))
```

This shouldn't interfere with the current implementation unless those variables are set.