### PR TITLE
Support Elm 0.19 "elm" sub-commands via customisation

### DIFF
--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -272,7 +272,7 @@ Stolen from ‘haskell-mode’."
   (elm-interactive-kill-current-session)
   (let* ((default-directory (elm--find-dependency-file-path))
          (origin (point-marker))
-         (cmd (append elm-interactive-command elm-interactive-arguments)))
+         (cmd (append (elm--ensure-list elm-interactive-command) elm-interactive-arguments)))
 
     (setq elm-interactive--current-project default-directory)
     (let ((buffer (get-buffer-create elm-interactive--buffer-name)))
@@ -326,6 +326,11 @@ of the file specified."
       (elm-interactive--send-command (concat line " \\\n")))
     (elm-interactive--send-command "\n")))
 
+(defun elm--ensure-list (v)
+  "Return V if it is a list, otherwise a single-element list containing V."
+  (if (consp v)
+      v
+    (list v)))
 
 ;;; Reactor:
 ;;;###autoload
@@ -338,7 +343,7 @@ of the file specified."
     (when process
       (delete-process process))
 
-    (let ((cmd (append elm-reactor-command elm-reactor-arguments)))
+    (let ((cmd (append (elm--ensure-list elm-reactor-command) elm-reactor-arguments)))
       (apply #'start-process elm-reactor--process-name elm-reactor--buffer-name
              (car cmd) (cdr cmd)))))
 
@@ -374,7 +379,7 @@ Runs `elm-reactor' first."
                      (list (concat "--output=" (expand-file-name output))))
            elm-compile-arguments)))
     (s-join " "
-            (append elm-compile-command
+            (append (elm--ensure-list elm-compile-command)
                     (mapcar 'shell-quote-argument
                             (append (list file)
                                     elm-compile-arguments
@@ -562,7 +567,7 @@ Each is captured as a group.")
 (defun elm-package--get-marked-install-commands ()
   "Get a list of the commands required to install the marked packages."
   (-map (lambda (package)
-          (s-join " " (append elm-package-command elm-package-arguments (list package))))
+          (s-join " " (append (elm--ensure-list elm-package-command) elm-package-arguments (list package))))
         (elm-package--get-marked-packages)))
 
 (defun elm-package--read-dependencies ()

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -271,24 +271,17 @@ Stolen from ‘haskell-mode’."
   (interactive)
   (elm-interactive-kill-current-session)
   (let* ((default-directory (elm--find-dependency-file-path))
-         (buffer (comint-check-proc elm-interactive--process-name))
-         (origin (point-marker)))
+         (origin (point-marker))
+         (cmd (append elm-interactive-command elm-interactive-arguments)))
 
     (setq elm-interactive--current-project default-directory)
-
-    (pop-to-buffer
-     (if (or buffer (not (derived-mode-p 'elm-interactive-mode))
-             (comint-check-proc (current-buffer)))
-         (get-buffer-create (or buffer elm-interactive--buffer-name))
-       (current-buffer)))
-
-    (unless buffer
-      (let ((cmd (append elm-interactive-command elm-interactive-arguments)))
-        (apply #'make-comint-in-buffer elm-interactive--process-name buffer
-               (car cmd) nil (cdr cmd)))
-      (elm-interactive-mode))
-
-    (setq-local elm-repl--origin origin)))
+    (let ((buffer (get-buffer-create elm-interactive--buffer-name)))
+      (apply #'make-comint-in-buffer elm-interactive--process-name buffer
+             (car cmd) nil (cdr cmd))
+      (elm-interactive-mode)
+      (with-current-buffer buffer
+        (setq-local elm-repl--origin origin))
+      (pop-to-buffer buffer))))
 
 (defun elm-repl-return-to-origin ()
   "Jump back to the location from which we last jumped to the repl."

--- a/elm-util.el
+++ b/elm-util.el
@@ -41,9 +41,12 @@
   :type 'number
   :group 'elm-util)
 
-(defconst elm-package-json
+(defcustom elm-package-json
   "elm-package.json"
-  "The name of the package JSON configuration file.")
+  "The name of the package JSON configuration file.
+Set to \"elm.json\" for use with Elm 0.19."
+  :type 'string
+  :group 'elm-util)
 
 (defun elm--get-module-name ()
   "Return the qualified name of the module in the current buffer."


### PR DESCRIPTION
Default commands are still those for Elm 0.18, but Elm 0.19's commands can now be used by setting the appropriate custom vars as follows, or in directory local variables for an Elm 0.19 project:

```
  (setq elm-interactive-command '("elm" "repl")
        elm-reactor-command '("elm" "reactor")
        elm-compile-command '("elm" "make")
        elm-package-command '("elm" "package"))
```

Tested with 0.18 - looking for feedback from a 0.19 user that this works.