### PR TITLE
fix required package versions

### DIFF
--- a/elm-mode.el
+++ b/elm-mode.el
@@ -4,7 +4,7 @@
 ;; Copyright (C) 2015, 2016  Bogdan Popa
 
 ;; Author: Joseph Collard
-;; Package-Requires: ((f "0.17") (let-alist "1.0.4") (seq "2.2") (s "1.7.0") (emacs "24.4") (dash "2.13.0"))
+;; Package-Requires: ((f "0.17") (let-alist "1.0.5") (seq "2.2") (s "1.7.0") (emacs "24.4") (dash "2.13.0"))
 ;; URL: https://github.com/jcollard/elm-mode
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
I tried installing elm-mode, and I received an error that let-alist-1.0.4 was required, but only 1.0.5 was found. I hit GNU ELPA and it looks like 1.0.5 is the latest available.