### PR TITLE
 Change formatter option to work with the latest elm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ Set or customize `elm-format-on-save` to `t` to apply `elm-format` on
 the current buffer on every save.
 
 Set or customize `elm-format-elm-version` to change which version of
-Elm to format against. Valid options are `0.17` and `0.16`. The
-default is `0.17`.
+Elm to format against. Valid options are `0.19`, `0.18`, `0.17` and `0.16`. The
+default is `0.19`.
 
 #### `elm-test`
 

--- a/elm-format.el
+++ b/elm-format.el
@@ -30,10 +30,11 @@
   :group 'elm-format
   :type 'boolean)
 
-(defcustom elm-format-elm-version "0.18"
+(defcustom elm-format-elm-version "0.19"
   "The version of Elm against which code should be formatted."
   :group 'elm-format
-  :type '(choice (const :tag "Default: 0.18" "0.18")
+  :type '(choice (const :tag "Default: 0.19" "0.19")
+		 (const :tag "0.18" "0.18")
                  (const :tag "0.17" "0.17")
                  (const :tag "0.16" "0.16")))
 


### PR DESCRIPTION
Hi.

Since `elm-format-elm-version` default value is still 0.18, I changed it to 0.19.

Updated default values and `README.md`.