### PR TITLE
Add function to replace inferior-haskell-flash-decl

### DIFF
--- a/elm-util.el
+++ b/elm-util.el
@@ -69,9 +69,11 @@ Relies on `haskell-mode' stuff."
            (end (or (haskell-ds-forward-decl) (point-max)))
            (raw-decl (s-trim-right (buffer-substring start end)))
            (lines (split-string raw-decl "\n"))
-           (first-line (car lines)))
+           (first-line (car lines))
+           ;; Shadow the defcustom pulse-delay variable.
+           (pulse-delay (/ elm-flash-duration 10.0)))
 
-      (inferior-haskell-flash-decl start end elm-flash-duration)
+      (pulse-momentary-highlight-region start end)
       (if (string-match-p "^[a-z].*:" first-line)
           (cdr lines)
         lines))))


### PR DESCRIPTION
In haskell-mode, there is no longer a function inferior-haskell-flash-decl, so
this brings the same functionality into elm-mode as a private function.

This was removed from haskell-mode in https://github.com/haskell/haskell-mode/commit/ca94d814b943afeea5bc418df3773f19be9ac8e3.