### PR TITLE
Use haskell-mode paragraph detection rules.

### DIFF
--- a/elm-mode.el
+++ b/elm-mode.el
@@ -157,7 +157,8 @@ Find the roots of this function in the c-awk-mode."
   (setq-local comment-start "--")
   (setq-local comment-end "")
   (setq-local imenu-create-index-function #'elm-imenu-create-index)
-  (setq-local paragraph-separate "\\(\r\t\n\\|-}\\)$")
+  (setq-local paragraph-start (concat " *{-\\| *-- |\\|" page-delimiter))
+  (setq-local paragraph-separate (concat " *$\\| *\\({-\\|-}\\) *$\\|" page-delimiter))
   (setq-local beginning-of-defun-function #'elm-beginning-of-defun)
   (setq-local end-of-defun-function #'elm-end-of-defun)
 


### PR DESCRIPTION
Closes #163 

I'm wondering if it's worth using anything other than default for `paragraph-separate` It's a little counter-intuitive to navigate through a doc-comment and then the defun as two separate paragraphs.

This also leaves the following problem. If the point is in the indicated position, `(forward-paragraph)` doesn't continue past the comment closing:

```elm
module Example exposing (f, g, h)


f : String -> String -> String
f x y =
    x ++ y

<-- point here
{-| A doc comment
-} <-- (forward-paragraph) goes before the -} 
g : String -> String -> List String
g x y =
    [ y, x ]


h : Int -> Int -> Int
h x y =
    x + y

```

That means that `dap` will delete the comment close in addition to `g`.

I'm not sure being able to fill-paragraph a doc comment is really worth it. But the current PR does preserve the fill-paragraph behavior as before.

The PR also fixes the paragraph detection in a buffer with trailing whitespace.