### PR TITLE
Apply package-lint to all files, and fix reported issues as necessary

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,5 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((elm-mode
+  (package-lint-main-file . "elm-mode.el")))

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ INIT_PACKAGES="(progn \
 all: compile package-lint clean-elc
 
 package-lint:
-	${EMACS} -Q --eval ${INIT_PACKAGES} -batch -f package-lint-batch-and-exit elm-mode.el
+	${EMACS} -Q --eval ${INIT_PACKAGES} --eval '(setq package-lint-main-file "elm-mode.el")' -batch -f package-lint-batch-and-exit *.el
 
 compile: clean-elc
 	${EMACS} -Q --eval ${INIT_PACKAGES} -L . -batch -f batch-byte-compile *.el

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ use [company-mode][company] for auto-completion, add the Elm backend
 to the backend list:
 
 ```elisp
-(add-to-list 'company-backends 'company-elm)
+(add-to-list 'company-backends 'elm-company)
 ```
 
 The Company backend supports `company-quickhelp` to display

--- a/elm-font-lock.el
+++ b/elm-font-lock.el
@@ -199,7 +199,7 @@ Also highlights opening brackets without a matching bracket."
               elm--font-lock-operators)
         nil nil))
 
-(defun turn-on-elm-font-lock ()
+(defun elm--font-lock-enable ()
   "Turn on Elm font lock."
   (setq font-lock-multiline t)
   (set-syntax-table elm--syntax-table)

--- a/elm-indent.el
+++ b/elm-indent.el
@@ -6,10 +6,6 @@
 
 ;; Author: 1997-1998 Guy Lapalme <lapalme@iro.umontreal.ca>
 
-;; Keywords: indentation Elm layout-rule
-;; Version: 1.2
-;; URL: http://www.iro.umontreal.ca/~lapalme/layout/index.html
-
 ;; This file is not part of GNU Emacs.
 
 ;; This file was adapted from `haskell-indent.el'.

--- a/elm-indent.el
+++ b/elm-indent.el
@@ -1233,13 +1233,6 @@ Invokes `elm-indent-hook' if not nil."
     (kill-local-variable 'indent-line-function)
     (kill-local-variable 'indent-region-function)))
 
-;;;###autoload
-(define-obsolete-function-alias 'turn-on-elm-indent 'elm-indent-mode)
-
-(defun turn-off-elm-indent ()
-  "Turn off ``intelligent'' Elm indentation mode."
-  (elm-indent-mode nil))
-
 
 (provide 'elm-indent)
 ;;; elm-indent.el ends here

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -263,7 +263,7 @@ Stolen from ‘haskell-mode’."
 
   (add-hook 'comint-output-filter-functions #'elm-interactive--spot-prompt nil t)
 
-  (turn-on-elm-font-lock))
+  (elm--font-lock-enable))
 
 ;;;###autoload
 (defun run-elm-interactive ()

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -60,7 +60,7 @@ For Elm 0.18 and earlier, set this to '(\"elm-repl\")."
   :group 'elm)
 
 (defvar elm-interactive-prompt-regexp "^[>|] "
-  "Prompt for `run-elm-interactive'.")
+  "Prompt for `elm-interactive'.")
 
 (defcustom elm-reactor-command '("elm" "reactor")
   "The Elm Reactor command.
@@ -253,7 +253,7 @@ Stolen from ‘haskell-mode’."
 
 ;;;###autoload
 (define-derived-mode elm-interactive-mode comint-mode "Elm Interactive"
-  "Major mode for `run-elm-interactive'.
+  "Major mode for `elm-interactive'.
 
 \\{elm-interactive-mode-map}"
 
@@ -266,7 +266,7 @@ Stolen from ‘haskell-mode’."
   (elm--font-lock-enable))
 
 ;;;###autoload
-(defun run-elm-interactive ()
+(defun elm-interactive ()
   "Run an inferior instance of `elm-repl' inside Emacs."
   (interactive)
   (elm-interactive-kill-current-session)
@@ -282,6 +282,9 @@ Stolen from ‘haskell-mode’."
         (elm-interactive-mode)
         (setq-local elm-repl--origin origin))
       (pop-to-buffer buffer))))
+
+;;;###autoload
+(define-obsolete-function-alias 'run-elm-interactive 'elm-interactive "2020-04")
 
 (defun elm-repl-return-to-origin ()
   "Jump back to the location from which we last jumped to the repl."
@@ -301,7 +304,7 @@ of the file specified."
   (interactive)
   (save-buffer)
   (let ((import-statement (elm--build-import-statement)))
-    (run-elm-interactive)
+    (elm-interactive)
     (elm-interactive--send-command ":reset\n")
     (elm-interactive--send-command import-statement)))
 
@@ -311,7 +314,7 @@ of the file specified."
   (interactive "r")
   (let* ((to-push (buffer-substring-no-properties beg end))
          (lines (split-string (s-trim-right to-push) "\n")))
-    (run-elm-interactive)
+    (elm-interactive)
     (dolist (line lines)
       (elm-interactive--send-command (concat line " \\\n")))
     (elm-interactive--send-command "\n")))
@@ -321,7 +324,7 @@ of the file specified."
   "Push the current top level declaration to the REPL."
   (interactive)
   (let ((lines (elm--get-decl)))
-    (run-elm-interactive)
+    (elm-interactive)
     (dolist (line lines)
       (elm-interactive--send-command (concat line " \\\n")))
     (elm-interactive--send-command "\n")))

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -345,7 +345,7 @@ of the file specified."
 
 ;;; Reactor:
 ;;;###autoload
-(defun run-elm-reactor ()
+(defun elm-reactor ()
   "Run the Elm reactor process."
   (interactive)
   (let ((default-directory (elm--find-dependency-file-path))
@@ -365,11 +365,14 @@ of the file specified."
         (when proc
           (set-process-filter proc 'comint-output-filter))))))
 
+;;;###autoload
+(define-obsolete-function-alias 'run-elm-reactor 'elm-reactor "2020-04")
+
 (defun elm-reactor--browse (path &optional debug)
   "Open (reactor-relative) PATH in browser with optional DEBUG.
 
 Runs `elm-reactor' first."
-  (run-elm-reactor)
+  (elm-reactor)
   (browse-url (format "http://localhost:%s/%s%s" elm-reactor-port path (if debug "?debug" ""))))
 
 ;;;###autoload

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -979,7 +979,7 @@ elm-specific `completion-at-point' function."
                #'elm-oracle-completion-at-point-function))
 
 (defvar ac-sources)
-(defvar ac-source-elm
+(defvar elm-ac-source
   `((candidates . (elm-oracle--get-completions ac-prefix t))
     (prefix . ,elm-oracle--pattern)))
 
@@ -987,7 +987,7 @@ elm-specific `completion-at-point' function."
 (defun elm-oracle-setup-ac ()
   "Set up auto-complete support.
 Add this function to your `elm-mode-hook'."
-  (add-to-list 'ac-sources 'ac-source-elm))
+  (add-to-list 'ac-sources 'elm-ac-source))
 
 
 (declare-function company-begin-backend "company")

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -994,18 +994,21 @@ Add this function to your `elm-mode-hook'."
 (declare-function company-doc-buffer "company")
 
 ;;;###autoload
-(defun company-elm (command &optional arg &rest ignored)
+(defun elm-company (command &optional arg &rest ignored)
   "Provide completion info according to COMMAND and ARG.  IGNORED is not used."
   (interactive (list 'interactive))
   (when (derived-mode-p 'elm-mode)
     (cl-case command
-      (interactive (company-begin-backend 'company-elm))
+      (interactive (company-begin-backend 'elm-company))
       (sorted t)
       (prefix (elm-oracle--completion-prefix-at-point))
       (doc-buffer (elm-company--docbuffer arg))
       (candidates (cons :async (apply-partially #'elm-company--candidates arg)))
       (annotation (elm-company--signature arg))
       (meta (elm-company--meta arg)))))
+
+;;;###autoload
+(define-obsolete-function-alias 'company-elm 'elm-company "2020-04")
 
 (defun elm-company--candidates (prefix &optional callback)
   "Function providing candidates for company-mode for given PREFIX.

--- a/elm-mode.el
+++ b/elm-mode.el
@@ -126,7 +126,7 @@ Find the roots of this function in the c-awk-mode."
     (define-key map (kbd "C-c C-l") 'elm-repl-load)
     (define-key map (kbd "C-c C-p") 'elm-repl-push)
     (define-key map (kbd "C-c C-e") 'elm-repl-push-decl)
-    (define-key map (kbd "C-c C-z") 'run-elm-interactive)
+    (define-key map (kbd "C-c C-z") 'elm-interactive)
     (define-key map (kbd "C-c C-a") 'elm-compile-add-annotations)
     (define-key map (kbd "C-c C-r") 'elm-compile-clean-imports)
     (define-key map (kbd "C-c C-c") 'elm-compile-buffer)

--- a/elm-mode.el
+++ b/elm-mode.el
@@ -168,7 +168,7 @@ Find the roots of this function in the c-awk-mode."
     (elm-format-on-save-mode))
   (add-hook 'after-save-hook #'elm-mode-after-save-handler nil t)
 
-  (turn-on-elm-font-lock))
+  (elm--font-lock-enable))
 
 ;; We enable intelligent indenting, but users can remove this from the
 ;; hook if they prefer.


### PR DESCRIPTION
`package-lint` now has preliminary support for checking "secondary" files in multi-file package, ie. all the `.el` files apart from `elm-mode.el` here.