### PR TITLE
Drop dash dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EMACS ?= emacs
 
 # A space-separated list of required package names
-NEEDED_PACKAGES = f s dash reformatter package-lint
+NEEDED_PACKAGES = f s reformatter package-lint
 
 INIT_PACKAGES="(progn \
   (require 'package) \

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -128,12 +128,12 @@ Args are expanded using `elm--expand-args'."
 
 (defvar elm-package-buffer-name "*elm-package*")
 
-(defcustom elm-package-command '("elm" "package")
+(defcustom elm-package-command '("elm")
   "The Elm package command."
   :type '(repeat string)
   :group 'elm)
 
-(defcustom elm-package-arguments '("install" "--yes")
+(defcustom elm-package-arguments '("install")
   "Command line arguments to pass to the Elm package command."
   :type '(repeat string)
   :group 'elm)
@@ -568,7 +568,7 @@ Each is captured as a group.")
   "Get packages that are marked for installation."
   (mapcar (lambda (id)
             (let-alist (nth id elm-package--contents)
-              (concat .name " " (elt .versions 0))))
+              .name))
           elm-package--marked-contents))
 
 (defun elm-package--get-marked-install-commands ()
@@ -757,7 +757,11 @@ Each is captured as a group.")
       (goto-char (point-min))
       (re-search-forward "^ *$")
       (setq elm-package--marked-contents nil)
-      (setq elm-package--contents (append (json-read) nil)))))
+      (setq elm-package--contents
+            (cl-loop for (name . versions) in (json-read)
+                     collect `((name . ,(symbol-name name))
+                               (versions . ,(nreverse versions))
+                               (summary . "")))))))
 
 ;;;###autoload
 (defun elm-import (refresh)

--- a/elm-mode.el
+++ b/elm-mode.el
@@ -4,7 +4,7 @@
 ;; Copyright (C) 2015, 2016  Bogdan Popa
 
 ;; Author: Joseph Collard
-;; Package-Requires: ((f "0.17") (s "1.7.0") (emacs "25.1") (dash "2.13.0") (reformatter "0.3"))
+;; Package-Requires: ((f "0.17") (s "1.7.0") (emacs "25.1") (seq "2.23") (reformatter "0.3"))
 ;; URL: https://github.com/jcollard/elm-mode
 ;; Package-Version: 0-snapshot
 


### PR DESCRIPTION
Given the availability of `seq` in recent years, there's no good reason to still use `dash`.