### PR TITLE
Fix cl-case so that it doesn't match 'quote

### DIFF
--- a/elm-indent.el
+++ b/elm-indent.el
@@ -641,12 +641,12 @@ than an identifier, a guard or rhs."
   (let ((elm-indent-info indent-info))
     (if (< start end-visible)
         (cl-case curr-line-type
-          ('empty (elm-indent-empty start end end-visible indent-info))
-          ('ident (elm-indent-ident start end end-visible indent-info))
-          ('guard (elm-indent-guard start end end-visible indent-info))
-          ('rhs   (elm-indent-rhs start end end-visible indent-info))
-          ('comment (error "Comment indent should never happen"))
-          ('other (elm-indent-other start end end-visible indent-info)))
+          (empty (elm-indent-empty start end end-visible indent-info))
+          (ident (elm-indent-ident start end end-visible indent-info))
+          (guard (elm-indent-guard start end end-visible indent-info))
+          (rhs   (elm-indent-rhs start end end-visible indent-info))
+          (comment (error "Comment indent should never happen"))
+          (other (elm-indent-other start end end-visible indent-info)))
       elm-indent-info)))
 
 (defun elm-indent-line-indentation (line-start line-end end-visible


### PR DESCRIPTION
While this won't ever happen, it shuts up a compilation warning. Explanation: `'other` becomes `(quote other)` which `cl-case` then interprets as a list, meaning "if it matches either the symbol `quote` or the symbol `other`, then follow this branch". 
Similar to how
```elisp
(cl-case x
  ((1 2) t))
```
will return `t` when x is either 1 or 2.

Maybe the [relevant part of the manual](https://www.gnu.org/software/emacs/manual/html_mono/cl.html#index-cl_002dcase) should be rewritten to make this more explicit…