### PR TITLE
Fix `elm-package-install` to be interactive

### DIFF
--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -743,7 +743,12 @@ Optionally PROMPT before inserting."
              (process (get-buffer-process buffer)))
         (setq elm-package--marked-contents nil)
         (with-current-buffer buffer
-          (set-process-sentinel process #'elm-package--install-sentinel))
+          (set-process-sentinel process
+                                (lambda (proc event)
+                                  (elm-package--install-sentinel proc event)
+                                  (when (and (memq (process-status proc) '(exit))
+                                             (= (process-exit-status proc) 0))
+                                    (kill-buffer (process-buffer proc))))))
         (pop-to-buffer buffer)))))
 
 ;;;###autoload

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -743,12 +743,7 @@ Optionally PROMPT before inserting."
              (process (get-buffer-process buffer)))
         (setq elm-package--marked-contents nil)
         (with-current-buffer buffer
-          (set-process-sentinel process
-                                (lambda (proc event)
-                                  (elm-package--install-sentinel proc event)
-                                  (when (and (memq (process-status proc) '(exit))
-                                             (= (process-exit-status proc) 0))
-                                    (kill-buffer (process-buffer proc))))))
+          (set-process-sentinel process #'elm-package--install-sentinel))
         (pop-to-buffer buffer)))))
 
 ;;;###autoload

--- a/elm-interactive.el
+++ b/elm-interactive.el
@@ -734,11 +734,17 @@ Optionally PROMPT before inserting."
          (command-to-run (s-join and (elm-package--get-marked-install-commands))))
     (when (yes-or-no-p (concat "Install " (s-join ", " (elm-package--get-marked-packages)) " ?"))
       (let* ((default-directory elm-package--working-dir)
-             (compilation-buffer-name-function (lambda (_) elm-package-compile-buffer-name))
-             (compilation-buffer (compile command-to-run)))
+             (buffer (make-comint-in-buffer "elm-package-install"
+                                            elm-package-compile-buffer-name
+                                            shell-file-name
+                                            nil
+                                            shell-command-switch
+                                            command-to-run))
+             (process (get-buffer-process buffer)))
         (setq elm-package--marked-contents nil)
-        (set-process-sentinel (get-buffer-process compilation-buffer)
-                              #'elm-package--install-sentinel)))))
+        (with-current-buffer buffer
+          (set-process-sentinel process #'elm-package--install-sentinel))
+        (pop-to-buffer buffer)))))
 
 ;;;###autoload
 (defun elm-package-catalog (refresh)


### PR DESCRIPTION
Maybe I've been doing it incorrectly but I could never get `elm-package-install` to work. I always get this output


> -*- mode: compilation; default-directory: "~/Projects/elm_thing" -*-
> Compilation started at Sat Dec 14 10:02:14
> 
> elm install 0ui/elm-task-parallel
> alias: expected <= 2 arguments; got 3
> Here is my plan:
>   
>   Add:
>     0ui/elm-task-parallel    2.0.0
> 
> Would you like me to update your elm.json accordingly? [Y/n]: 

but I'm unable to interact with the buffer to send `Y`. This PR uses a comint buffer so the user can interact with `elm install` output and choose Y or n

## Demo
This shows an unsuccessful install, followed by a successful one

https://github.com/user-attachments/assets/46b217be-ab55-4dcc-93de-c571a4094bbe
